### PR TITLE
build: add Makefile for arduino-less environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 nRF24_multipro/Debug
 nRF24_multipro/Release
 nRF24_multipro/Visual Micro
+*.o
+*.elf
+*.hex
+*.map
+*~
+nRF24_multipro/prototypes.h

--- a/nRF24_multipro/Makefile
+++ b/nRF24_multipro/Makefile
@@ -1,0 +1,64 @@
+CROSS_COMPILE := avr-
+ARDUINO := ./Arduino
+
+DEFINES = -DARDUINO=180 \
+	  -DF_CPU=16000000UL
+
+INCLUDES = -I$(ARDUINO)/hardware/arduino/avr/cores/arduino/ \
+	   -I$(ARDUINO)/hardware/arduino/avr/variants/eightanaloginputs \
+	   -I$(ARDUINO)/hardware/arduino/avr/libraries/SPI/src/ \
+	   -I$(ARDUINO)/hardware/arduino/avr/libraries/EEPROM/src/
+
+INO_INCLUDES = -include iface_nrf24l01.h \
+	       -include common.h \
+	       -include prototypes.h
+
+CFLAGS = $(DEFINES) $(INCLUDES) -mmcu=atmega328p \
+	 -fdata-sections -ffunction-sections \
+	 -Os
+
+CXXFLAGS = $(CFLAGS) -std=c++11 -fno-threadsafe-statics -fno-rtti -fno-exceptions
+LDFLAGS = -Wl,-gc-sections -Wl,-Map=nRF24_multipro.map -Wl,--warn-common
+
+INO_SRC = $(wildcard *.ino)
+
+ARDUINO_SRC = $(ARDUINO)/hardware/arduino/avr/cores/arduino/hooks.c \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/WMath.cpp \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/WInterrupts.c \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/wiring.c \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/wiring_digital.c \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/wiring_analog.c \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/HardwareSerial.cpp \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/HardwareSerial0.cpp \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/Print.cpp \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/abi.cpp \
+	      $(ARDUINO)/hardware/arduino/avr/cores/arduino/main.cpp
+
+
+OBJS = $(INO_SRC:.ino=.o) $(patsubst %.cpp,%.o,$(ARDUINO_SRC:.c=.o))
+
+nRF24_multipro.hex:
+
+nRF24_multipro.elf: $(OBJS)
+	$(CROSS_COMPILE)g++ $(CXXFLAGS) $(LDFLAGS) $(OBJS) -o $@
+
+prototypes.h: $(INO_SRC)
+	cat *.ino | tr -d '\r' | \
+		sed -rn '/^[a-z]+.*\)[ ]*$$/ {s/$$/;/; p}; /^#define/ p' > prototypes.h || rm prototypes.h
+
+%.o: %.ino prototypes.h common.h
+	$(CROSS_COMPILE)g++ $(CXXFLAGS) $(INO_INCLUDES) -c -x c++ $< -o $@
+
+%.o: %.cpp
+	$(CROSS_COMPILE)g++ $(CXXFLAGS) -c $< -o $@
+
+%.o: %.c
+	$(CROSS_COMPILE)gcc $(CFLAGS) -c $< -o $@
+
+%.hex: %.elf
+	$(CROSS_COMPILE)objcopy -O ihex $< $@
+
+clean:
+	-rm $(OBJS) *.elf *.hex *.map prototypes.h
+
+.PHONY: clean

--- a/nRF24_multipro/common.h
+++ b/nRF24_multipro/common.h
@@ -1,0 +1,55 @@
+#ifndef _COMMON_H
+#define _COMMON_H
+
+// supported protocols
+enum {
+	PROTO_V2X2 = 0,     // WLToys V2x2, JXD JD38x, JD39x, JJRC H6C, Yizhan Tarantula X6 ...
+	PROTO_CG023,        // EAchine CG023, CG032, 3D X4
+	PROTO_CX10_BLUE,    // Cheerson CX-10 blue board, newer red board, CX-10A, CX-10C, Floureon FX-10, CX-Stars (todo: add DM007 variant)
+	PROTO_CX10_GREEN,   // Cheerson CX-10 green board
+	PROTO_H7,           // EAchine H7, MoonTop M99xx
+	PROTO_BAYANG,       // EAchine H8(C) mini, H10, BayangToys X6, X7, X9, JJRC JJ850, Floureon H101
+	PROTO_SYMAX5C1,     // Syma X5C-1 (not older X5C), X11, X11C, X12
+	PROTO_YD829,        // YD-829, YD-829C, YD-822 ...
+	PROTO_H8_3D,        // EAchine H8 mini 3D, JJRC H20, H22
+	PROTO_MJX,          // MJX X600 (can be changed to Weilihua WLH08, X800 or H26D)
+	PROTO_SYMAXOLD,     // Syma X5C, X2
+	PROTO_HISKY,        // HiSky RXs, HFP80, HCP80/100, FBL70/80/90/100, FF120, HMX120, WLToys v933/944/955 ...
+	PROTO_KN,           // KN (WLToys variant) V930/931/939/966/977/988
+	PROTO_YD717,        // Cheerson CX-10 red (older version)/CX11/CX205/CX30, JXD389/390/391/393, SH6057/6043/6044/6046/6047, FY326Q7, WLToys v252 Pro/v343, XinXun X28/X30/X33/X39/X40
+	PROTO_FQ777124,     // FQ777-124 pocket drone
+	PROTO_E010,         // EAchine E010, NiHui NH-010, JJRC H36 mini
+	PROTO_BAYANG_SILVERWARE, // Bayang for Silverware with frsky telemetry
+	PROTO_END
+};
+
+enum chan_order {
+	THROTTLE,
+	AILERON,
+	ELEVATOR,
+	RUDDER,
+	AUX1,  // (CH5)  led light, or 3 pos. rate on CX-10, H7, or inverted flight on H101
+	AUX2,  // (CH6)  flip control
+	AUX3,  // (CH7)  still camera (snapshot)
+	AUX4,  // (CH8)  video camera
+	AUX5,  // (CH9)  headless
+	AUX6,  // (CH10) calibrate Y (V2x2), pitch trim (H7), RTH (Bayang, H20), 360deg flip mode (H8-3D, H22)
+	AUX7,  // (CH11) calibrate X (V2x2), roll trim (H7)
+	AUX8,  // (CH12) Reset / Rebind
+};
+
+struct telemetry_data_t {
+	uint16_t volt1;
+	uint16_t rssi;
+	uint8_t updated;
+	uint32_t lastUpdate;
+};
+
+extern struct telemetry_data_t telemetry_data;
+extern uint16_t ppm[12];
+extern uint8_t packet[32];
+extern uint8_t transmitterID[4];
+extern uint8_t current_protocol;
+extern bool reset;
+
+#endif

--- a/nRF24_multipro/nRF24_multipro.ino
+++ b/nRF24_multipro/nRF24_multipro.ino
@@ -30,6 +30,7 @@
 
 #include <util/atomic.h>
 #include <EEPROM.h>
+#include "common.h"
 #include "iface_nrf24l01.h"
 
 
@@ -63,20 +64,6 @@
 
 // PPM stream settings
 #define CHANNELS 12 // number of channels in ppm stream, 12 ideally
-enum chan_order{
-    THROTTLE,
-    AILERON,
-    ELEVATOR,
-    RUDDER,
-    AUX1,  // (CH5)  led light, or 3 pos. rate on CX-10, H7, or inverted flight on H101
-    AUX2,  // (CH6)  flip control
-    AUX3,  // (CH7)  still camera (snapshot)
-    AUX4,  // (CH8)  video camera
-    AUX5,  // (CH9)  headless
-    AUX6,  // (CH10) calibrate Y (V2x2), pitch trim (H7), RTH (Bayang, H20), 360deg flip mode (H8-3D, H22)
-    AUX7,  // (CH11) calibrate X (V2x2), roll trim (H7)
-    AUX8,  // (CH12) Reset / Rebind
-};
 
 #define PPM_MIN 1000
 #define PPM_SAFE_THROTTLE 1050 
@@ -87,28 +74,6 @@ enum chan_order{
 #define GET_FLAG(ch, mask) (ppm[ch] > PPM_MAX_COMMAND ? mask : 0)
 #define GET_FLAG_INV(ch, mask) (ppm[ch] < PPM_MIN_COMMAND ? mask : 0)
 
-// supported protocols
-enum {
-    PROTO_V2X2 = 0,     // WLToys V2x2, JXD JD38x, JD39x, JJRC H6C, Yizhan Tarantula X6 ...
-    PROTO_CG023,        // EAchine CG023, CG032, 3D X4
-    PROTO_CX10_BLUE,    // Cheerson CX-10 blue board, newer red board, CX-10A, CX-10C, Floureon FX-10, CX-Stars (todo: add DM007 variant)
-    PROTO_CX10_GREEN,   // Cheerson CX-10 green board
-    PROTO_H7,           // EAchine H7, MoonTop M99xx
-    PROTO_BAYANG,       // EAchine H8(C) mini, H10, BayangToys X6, X7, X9, JJRC JJ850, Floureon H101
-    PROTO_SYMAX5C1,     // Syma X5C-1 (not older X5C), X11, X11C, X12
-    PROTO_YD829,        // YD-829, YD-829C, YD-822 ...
-    PROTO_H8_3D,        // EAchine H8 mini 3D, JJRC H20, H22
-    PROTO_MJX,          // MJX X600 (can be changed to Weilihua WLH08, X800 or H26D)
-    PROTO_SYMAXOLD,     // Syma X5C, X2
-    PROTO_HISKY,        // HiSky RXs, HFP80, HCP80/100, FBL70/80/90/100, FF120, HMX120, WLToys v933/944/955 ...
-    PROTO_KN,           // KN (WLToys variant) V930/931/939/966/977/988
-    PROTO_YD717,        // Cheerson CX-10 red (older version)/CX11/CX205/CX30, JXD389/390/391/393, SH6057/6043/6044/6046/6047, FY326Q7, WLToys v252 Pro/v343, XinXun X28/X30/X33/X39/X40
-    PROTO_FQ777124,     // FQ777-124 pocket drone
-    PROTO_E010,         // EAchine E010, NiHui NH-010, JJRC H36 mini
-    PROTO_BAYANG_SILVERWARE, // Bayang for Silverware with frsky telemetry
-    PROTO_END
-};
-
 // EEPROM locationss
 enum{
     ee_PROTOCOL_ID = 0,
@@ -118,20 +83,15 @@ enum{
     ee_TXID3
 };
 
-struct {
-    uint16_t volt1;
-    uint16_t rssi;
-    uint8_t updated;
-    uint32_t lastUpdate;
-} telemetry_data;
+struct telemetry_data_t telemetry_data;
 
 uint8_t transmitterID[4];
 uint8_t current_protocol;
 static volatile bool ppm_ok = false;
 uint8_t packet[32];
-static bool reset=true;
+bool reset=true;
 volatile uint16_t Servo_data[12];
-static uint16_t ppm[12] = {PPM_MIN,PPM_MIN,PPM_MIN,PPM_MIN,PPM_MID,PPM_MID,
+uint16_t ppm[12] = {PPM_MIN,PPM_MIN,PPM_MIN,PPM_MIN,PPM_MID,PPM_MID,
                            PPM_MID,PPM_MID,PPM_MID,PPM_MID,PPM_MID,PPM_MID,};
 
 void setup()


### PR DESCRIPTION
Hello goebish,

First of all, thank you for making this project free software!

Let me explain my motivation behind this proposal. I would really like to be able to build your firmware without the Arduino IDE (cloning a copy of their libraries is not a problem). I assumed that you're targetting arduino nano board (with atmega32u chip) so I wrote a suitable Makefile. As you can see, treatment of .ino files is a bit hackish, and I had to make some minimal changes to the codebase to make it compile. I would prefer to convert all .ino files to .cpp properly and get rid of the "prototypes.h" hackery, so if you say you might accept such a proposal, I can prepare it shortly.

My next step is to port the code to the "bluepill" stm32f103 board, and I have already managed to build it (with PPM decoding commented out). And then I'm planning on trying to merge this with https://github.com/paulfertser/stm32-tx-hid functionality to be able to use any simple toy Tx to control models.

Please let me know what you think.

If you prefer to contact me via e-mail or IRC, please feel free to.

Have a nice day and happy hacking.